### PR TITLE
Prevent null access in client output handler

### DIFF
--- a/src/termproject/Client.java
+++ b/src/termproject/Client.java
@@ -116,37 +116,47 @@ class ThreadedOutputHandler extends Thread {
 
     public void run() {
         while (true) {
-        	if(g.sharedData.whoami == 0) {
-        		client.wait_sensed();
-        	}
-        	else { // 컴퓨터일때
-        		try {
-					sleep(1000);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-				}
-        	}
-        	
-        	System.out.println("OutputHandler wake up...");
-        	
-        	if(g.sharedData.whoami == 0) {
-            	try {
-            		String guess = g.getGuess();
-    	            System.out.println("guess : " + guess);
-    	            
-    	            if (guess != null && !guess.isEmpty()) {
-    	               os.writeBytes(guess + "\n");
-    	            }
-    	            client.char_sensed = false;
-    	         } catch (IOException e) {e.printStackTrace();}
-        	}
-        	else {
-        		try {
-					os.writeBytes('a' + "\n");
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-        	}
+            if (g.sharedData == null) {
+                try {
+                    // Wait for the initial shared data to arrive from the server
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                continue;
+            }
+
+            if(g.sharedData.whoami == 0) {
+                    client.wait_sensed();
+            }
+            else { // 컴퓨터일때
+                    try {
+                                    sleep(1000);
+                            } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                            }
+            }
+
+            System.out.println("OutputHandler wake up...");
+
+            if(g.sharedData.whoami == 0) {
+            try {
+                    String guess = g.getGuess();
+                System.out.println("guess : " + guess);
+
+                if (guess != null && !guess.isEmpty()) {
+                   os.writeBytes(guess + "\n");
+                }
+                client.char_sensed = false;
+             } catch (IOException e) {e.printStackTrace();}
+            }
+            else {
+                    try {
+                                    os.writeBytes('a' + "\n");
+                            } catch (IOException e) {
+                                    e.printStackTrace();
+                            }
+            }
 
         }
     }

--- a/src/termproject/SharedData.java
+++ b/src/termproject/SharedData.java
@@ -29,7 +29,7 @@ public class SharedData implements Serializable
 		String correct_state1 = String.format("%19s %s\n", "current correct(1):", Arrays.toString(correct_character_index[P1]));
 		String correct_state2 = String.format("%19s %s\n", "current correct(2):", Arrays.toString(correct_character_index[P2]));
 		String sum1 = String.format("%19s correct = %d, wrong = %d\n", "sum(1):", sum[P1][0], sum[P1][1]);
-		String sum2 = String.format("%19s correct = %d, wrong = %d\n", "sum(1):", sum[P2][0], sum[P2][1]);
+                String sum2 = String.format("%19s correct = %d, wrong = %d\n", "sum(2):", sum[P2][0], sum[P2][1]);
 		
 		return "\n" + introduce + correct_state1 + sum1 + correct_state2 + sum2;
 	}


### PR DESCRIPTION
## Summary
- Wait for shared data to arrive before using it in `ThreadedOutputHandler` to avoid null pointer issues
- Correct player label in `SharedData.toString`

## Testing
- `javac -d out $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68ba4a9b8948832d8e29373e9a252080